### PR TITLE
주문 비교 영역에 주문 패킹 리스트 데이터 적용

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
         "no-shadow": "off",
         "global-require": "off",
         "import/no-extraneous-dependencies":"off",
+        "no-nested-ternary": "off",
         "@typescript-eslint/no-use-before-define": ["error"],
         "import/extensions": [
             "error",

--- a/src/constants/order/order.ts
+++ b/src/constants/order/order.ts
@@ -1,0 +1,47 @@
+/**
+ * 박스 종류
+ */
+export const BOX_TYPE = {
+  /**
+   * 일반 상자
+   */
+  NORMAL: 'NORMAL',
+  /**
+   * 종이 파우치
+   */
+  POUCH: 'POUCH',
+  /**
+   * 퍼플 박스
+   */
+  PURPLE: 'PURPLE',
+};
+
+/**
+ * 냉매재 종류
+ */
+export const REFRIGERANT_TYPE = {
+  /**
+   * 아이스 팩
+   */
+  ICE_PACK: 'ICE_PACK',
+  /**
+   * 드라이 아이스
+   */
+  DRY_ICE: 'DRY_ICE',
+};
+
+// 상품 보관 종류
+export const COLD_TYPE = {
+  /**
+   * 상온 보관
+   */
+  NORMAL: 'NORMAL',
+  /**
+   * 냉장 보관
+   */
+  REFRIGERATED: 'REFRIGERATED',
+  /**
+   * 냉동 보관
+   */
+  FROZEN: 'FROZEN',
+};

--- a/src/hooks/query/order/types.ts
+++ b/src/hooks/query/order/types.ts
@@ -1,16 +1,35 @@
+import { BOX_TYPE, COLD_TYPE, REFRIGERANT_TYPE } from '@constants/order/order';
+
 /**
- * 추천 박스 타입
+ * 추천 박스 사이즈 타입
+ */
+export type boxType = typeof BOX_TYPE[keyof typeof BOX_TYPE];
+
+/**
+ * 냉매재 종류 타입
+ */
+export type refrigerantType =
+  typeof REFRIGERANT_TYPE[keyof typeof REFRIGERANT_TYPE];
+
+/**
+ * 냉장 보관 종류 타입
+ */
+export type coldType = typeof COLD_TYPE[keyof typeof COLD_TYPE];
+
+/**
+ * 추천 박스 옵션 타입
  */
 type boxOptionType = {
   size: string;
   amount: number;
+  type: boxType;
 };
 
 /**
  * 추천 냉매재 타입
  */
 export type refrigerantsOptionType = {
-  type: 'ICE_PACK' | 'DRY_ICE';
+  type: refrigerantType;
   size: string | null;
   amount: number | null;
 };
@@ -24,9 +43,23 @@ export type packingInfoType = {
 };
 
 /**
+ * 주문 상세 정보 타입
+ */
+export type orderDetailType = {
+  productId: number;
+  productName: string;
+  amount: number;
+  coldType: string;
+  isMatched: boolean;
+};
+
+/**
  * 주문 패킹 리스트 응답 데이터 타입
  */
 export type orderListResponseDataType = {
+  /**
+   * 스캔된 주문 기본 정보
+   */
   orderInfo: {
     orderId: number;
     customerName: string;
@@ -34,23 +67,24 @@ export type orderListResponseDataType = {
     orderDate: string;
   };
 
+  /**
+   * 포장 완료 목록
+   */
   packingInfo: packingInfoType;
 
-  orderDetails: {
-    productId: number;
-    productName: string;
-    amount: number;
-    coldType: string;
-  }[];
+  /**
+   * 주문 상세 정보
+   */
+  orderDetails: orderDetailType[];
 
-  recognitionResults: {
-    productId: number;
-    productName: string;
-    amount: number;
-    coldType: string;
-    isMatched: boolean;
-  }[];
+  /**
+   * Ai가 검수한 주문 정보 결과
+   */
+  recognitionResults: Omit<orderDetailType, 'isMatched'>[];
 
+  /**
+   * 권장 포장 옵션
+   */
   recommendedPackingOption: {
     box: boxOptionType;
     refrigerants: refrigerantsOptionType[];

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -66,12 +66,28 @@ export const handlers = [
               productName: '상품1',
               amount: 1,
               coldType: 'NORMAL',
+              isMatched: true,
             },
             {
               productId: 2,
               productName: '상품2',
               amount: 1,
               coldType: 'REFRIGERATED',
+              isMatched: false,
+            },
+            {
+              productId: 3,
+              productName: '상품3',
+              amount: 5,
+              coldType: 'NORMAL',
+              isMatched: false,
+            },
+            {
+              productId: 4,
+              productName: '상품4',
+              amount: 2,
+              coldType: 'FROZEN',
+              isMatched: false,
             },
           ],
           recognitionResults: [

--- a/src/views/Order/OrderAiQaSection/style.ts
+++ b/src/views/Order/OrderAiQaSection/style.ts
@@ -35,4 +35,6 @@ export const OrderAiQaSectionStyle = styled.section`
   }
 `;
 
-export const OrderQaListTableStyle = styled(Table)``;
+export const OrderQaListTableStyle = styled(Table)`
+  background-color: white;
+`;

--- a/src/views/Order/OrderContent/OrderContent.tsx
+++ b/src/views/Order/OrderContent/OrderContent.tsx
@@ -14,18 +14,16 @@ const OrderContent = () => {
   return (
     <OrderContentStyle>
       <ErrorBoundary fallback={<div>에러 발생!</div>}>
-        {/* AI 검수결과 테이블 영역 */}
         <Suspense fallback={<div>로딩중...</div>}>
+          {/* AI 검수결과 테이블 영역 */}
           <OrderAiQaSection
             orderId={orderId}
             packingOrderList={packingOrderList}
             setPackingOrderList={setPackingOrderList}
           />
-        </Suspense>
-        {/* 주문 비교 테이블 영역 */}
-        <OrderDetailSection />
-        {/* 주문 검수 결과 옵션 영역 */}
-        <Suspense fallback={<div>로딩중...</div>}>
+          {/* 주문 비교 테이블 영역 */}
+          <OrderDetailSection orderId={orderId} />
+          {/* 주문 검수 결과 옵션 영역 */}
           <OrderOptionSection orderId={orderId} setOrderId={setOrderId} />
         </Suspense>
       </ErrorBoundary>

--- a/src/views/Order/OrderDetailSection/OrderDetailSection.tsx
+++ b/src/views/Order/OrderDetailSection/OrderDetailSection.tsx
@@ -38,7 +38,9 @@ const OrderDetailSection: FC<IOrderDetailSectionProps> = props => {
           </div>
           <div className="order-date">
             <span className="order-detail-title">주문일시 : </span>
-            {data?.data?.orderInfo.orderDate.split('T')[0]}
+            {`${data?.data?.orderInfo.orderDate.split('T')[0]} (${
+              data?.data?.orderInfo.orderDate.split('T')[1]
+            })`}
           </div>
         </div>
       </OrderContainer>

--- a/src/views/Order/OrderDetailSection/OrderDetailSection.tsx
+++ b/src/views/Order/OrderDetailSection/OrderDetailSection.tsx
@@ -38,9 +38,10 @@ const OrderDetailSection: FC<IOrderDetailSectionProps> = props => {
           </div>
           <div className="order-date">
             <span className="order-detail-title">주문일시 : </span>
-            {`${data?.data?.orderInfo.orderDate.split('T')[0]} (${
-              data?.data?.orderInfo.orderDate.split('T')[1]
-            })`}
+            {data?.data?.orderInfo.orderDate &&
+              `${data?.data?.orderInfo.orderDate.split('T')[0]} (${
+                data?.data?.orderInfo.orderDate.split('T')[1]
+              })`}
           </div>
         </div>
       </OrderContainer>

--- a/src/views/Order/OrderDetailSection/OrderDetailSection.tsx
+++ b/src/views/Order/OrderDetailSection/OrderDetailSection.tsx
@@ -1,39 +1,52 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import Table from '@components/Table';
+import { useOrderList } from '@hooks/query/order/useOrderList';
 import { OrderDetailSectionStyle } from '@views/Order/OrderDetailSection/style';
 import OrderContainer from '@views/Order/common/OrderContainer';
 import OrderColumn from '@views/Order/column/OrderColumn';
+import OrderQaColumn from '@views/Order/column/OrderQaColumn';
 
-const OrderDetailSection = () => {
-  const mockData = [];
-  for (let i = 0; i < 10; i += 1) {
-    mockData.push({
-      number: `${i + 1}233-5341-3322-1233-4434`,
-      name: `상품 ${i + 1}`,
-      amount: `${i + 1}`,
-      type: `타입 ${i}`,
-    });
-  }
+interface IOrderDetailSectionProps {
+  orderId: number | null;
+}
+
+const OrderDetailSection: FC<IOrderDetailSectionProps> = props => {
+  const { orderId } = props;
+
+  const { data } = useOrderList(orderId, {
+    enabled: orderId !== null && orderId > 0,
+  });
 
   return (
     <OrderDetailSectionStyle>
-      <div className="packing-stage-number">현재 작업대 No: 1</div>
       <OrderContainer className="order-detail-section" title="스캔된 주문">
         <div className="order-detail-left-section">
-          <div className="order-number">주문번호: 12</div>
-          <div className="invoice-number">송장번호: 3333-4444-2222-1111</div>
+          <div className="order-number">
+            <span className="order-detail-title">주문번호 : </span>
+            {data?.data?.orderInfo.orderId}
+          </div>
+          <div className="invoice-number">
+            <span className="order-detail-title">송장번호 : </span>
+            {data?.data?.orderInfo.trackingNumber}
+          </div>
         </div>
         <div className="order-detail-right-section">
-          <div className="order-user">주문자명: 이진희</div>
-          <div className="order-date">주문일시: 2021-03-01</div>
+          <div className="order-user">
+            <span className="order-detail-title">주문자명 : </span>
+            {data?.data?.orderInfo.customerName}
+          </div>
+          <div className="order-date">
+            <span className="order-detail-title">주문일시 : </span>
+            {data?.data?.orderInfo.orderDate.split('T')[0]}
+          </div>
         </div>
       </OrderContainer>
       <div className="compare-order-detail">
         <OrderContainer title="주문상세">
           <Table
             columns={OrderColumn()}
-            dataSource={mockData}
+            dataSource={data?.data?.orderDetails}
             scroll={{
               y: 500,
             }}
@@ -41,8 +54,8 @@ const OrderDetailSection = () => {
         </OrderContainer>
         <OrderContainer title="Ai 검수결과">
           <Table
-            columns={OrderColumn()}
-            dataSource={mockData}
+            columns={OrderQaColumn()}
+            dataSource={data?.data?.recognitionResults}
             scroll={{
               y: 500,
             }}

--- a/src/views/Order/OrderDetailSection/style.ts
+++ b/src/views/Order/OrderDetailSection/style.ts
@@ -3,10 +3,6 @@ import styled from 'styled-components';
 export const OrderDetailSectionStyle = styled.section`
   width: 65%;
 
-  .packing-stage-number {
-    margin-bottom: 20px;
-  }
-
   .order-detail-section {
     & > div {
       &:last-child {
@@ -14,6 +10,7 @@ export const OrderDetailSectionStyle = styled.section`
 
         .order-detail-left-section,
         .order-detail-right-section {
+          font-weight: bold;
           flex-grow: 1;
 
           & > div {
@@ -25,6 +22,12 @@ export const OrderDetailSectionStyle = styled.section`
               margin-bottom: 6px;
             }
           }
+        }
+
+        .order-detail-title {
+          color: ${props => props.theme.color.pip_gray_02};
+          margin-right: 10px;
+          font-weight: 600;
         }
       }
     }

--- a/src/views/Order/OrderOptionSection/OrderOptionSection.tsx
+++ b/src/views/Order/OrderOptionSection/OrderOptionSection.tsx
@@ -7,6 +7,7 @@ import {
   DRY_ICE_IMAGE_PATH,
   ICE_PACK_IMAGE_PATH,
 } from '@constants/url/imageUrls';
+import { REFRIGERANT_TYPE } from '@constants/order/order';
 import theme from '@styles/theme';
 import { useOrderList } from '@hooks/query/order/useOrderList';
 import { refrigerantsOptionType } from '@hooks/query/order/types';
@@ -71,14 +72,14 @@ const OrderOptionSection: FC<IOrderOptionSectionProps> = props => {
    * 드라이 아이스 팩에 대한 추천 정보를 담고있는 객체
    */
   const dryIce = data?.data?.recommendedPackingOption?.refrigerants.filter(
-    (item: refrigerantsOptionType) => item.type === 'DRY_ICE',
+    (item: refrigerantsOptionType) => item.type === REFRIGERANT_TYPE.DRY_ICE,
   )[0];
 
   /**
    * 일반적인 아이스 팩에 대한 추천 정보를 담고있는 객체
    */
   const icePack = data?.data?.recommendedPackingOption?.refrigerants.filter(
-    (item: refrigerantsOptionType) => item.type === 'ICE_PACK',
+    (item: refrigerantsOptionType) => item.type === REFRIGERANT_TYPE.ICE_PACK,
   )[0];
 
   return (

--- a/src/views/Order/column/AiQaColumn/AiQaColumn.tsx
+++ b/src/views/Order/column/AiQaColumn/AiQaColumn.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { ColumnType } from 'antd/lib/table';
 
+/**
+ * 포장 완료 목록 테이블에 사용되는 column
+ * @constructor
+ */
 const AiQaColumn = () =>
   [
     {

--- a/src/views/Order/column/OrderColumn/OrderColumn.tsx
+++ b/src/views/Order/column/OrderColumn/OrderColumn.tsx
@@ -3,6 +3,7 @@ import { Tooltip } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 
 import { orderDetailType } from '@hooks/query/order/types';
+import theme from '@styles/theme';
 import { COLD_TYPE } from '@constants/order/order';
 
 /**
@@ -16,7 +17,17 @@ const OrderColumn = () =>
       dataIndex: 'isMatched',
       title: '일치여부',
       width: 30,
-      render: (record: boolean) => (record ? '일치' : '불일치'),
+      render: (record: boolean) => ({
+        props: {
+          style: {
+            backgroundColor: record
+              ? theme.color.pip_green
+              : theme.color.pip_red,
+            fontWeight: 'bold',
+          },
+        },
+        children: record ? '일치' : '불일치',
+      }),
       sorter: (a: orderDetailType, b: orderDetailType) =>
         a.isMatched === b.isMatched ? 0 : a.isMatched ? 1 : -1,
     },

--- a/src/views/Order/column/OrderColumn/OrderColumn.tsx
+++ b/src/views/Order/column/OrderColumn/OrderColumn.tsx
@@ -2,16 +2,34 @@ import React from 'react';
 import { Tooltip } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 
+import { orderDetailType } from '@hooks/query/order/types';
+import { COLD_TYPE } from '@constants/order/order';
+
+/**
+ * 주문상세 테이블에 해당하는 column
+ * @constructor
+ */
 const OrderColumn = () =>
   [
     {
-      title: '상품번호',
-      dataIndex: 'number',
-      width: 20,
+      key: 'isMatched',
+      dataIndex: 'isMatched',
+      title: '일치여부',
+      width: 30,
+      render: (record: boolean) => (record ? '일치' : '불일치'),
+      sorter: (a: orderDetailType, b: orderDetailType) =>
+        a.isMatched === b.isMatched ? 0 : a.isMatched ? 1 : -1,
     },
     {
+      key: 'productId',
+      dataIndex: 'productId',
+      title: '상품번호',
+      width: 30,
+    },
+    {
+      key: 'productName',
+      dataIndex: 'productName',
       title: '상품이름',
-      dataIndex: 'name',
       width: 40,
       ellipsis: {
         showTitle: false,
@@ -23,14 +41,28 @@ const OrderColumn = () =>
       ),
     },
     {
-      title: '수량',
+      key: 'amount',
       dataIndex: 'amount',
-      width: 15,
+      title: '수량',
+      width: 20,
     },
     {
+      key: 'coldType',
+      dataIndex: 'coldType',
       title: '타입',
-      dataIndex: 'type',
-      width: 15,
+      width: 20,
+      render: (record: string) => {
+        switch (record) {
+          case COLD_TYPE.NORMAL:
+            return '상온';
+          case COLD_TYPE.REFRIGERATED:
+            return '냉장';
+          case COLD_TYPE.FROZEN:
+            return '냉동';
+          default:
+            return '';
+        }
+      },
     },
   ].map(item => ({
     ...item,

--- a/src/views/Order/column/OrderQaColumn/OrderQaColumn.tsx
+++ b/src/views/Order/column/OrderQaColumn/OrderQaColumn.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Tooltip } from 'antd';
+import { ColumnType } from 'antd/lib/table';
+
+/**
+ * Ai 검수결과 테이블에 해당하는 column
+ * @constructor
+ */
+const OrderQaColumn = () =>
+  [
+    {
+      key: 'productId',
+      dataIndex: 'productId',
+      title: '상품번호',
+      width: 20,
+    },
+    {
+      key: 'productName',
+      dataIndex: 'productName',
+      title: '상품이름',
+      width: 40,
+      ellipsis: {
+        showTitle: false,
+      },
+      render: (number: number) => (
+        <Tooltip placement="topLeft" title={number}>
+          {number}
+        </Tooltip>
+      ),
+    },
+    {
+      key: 'amount',
+      dataIndex: 'amount',
+      title: '수량',
+      width: 15,
+    },
+    {
+      key: 'coldType',
+      dataIndex: 'coldType',
+      title: '타입',
+      width: 15,
+      render: (record: string) => (record === 'NORMAL' ? '냉장' : '냉동'),
+    },
+  ].map(item => ({
+    ...item,
+    align: 'center' as ColumnType<never>['align'],
+  }));
+
+export default OrderQaColumn;

--- a/src/views/Order/column/OrderQaColumn/index.tsx
+++ b/src/views/Order/column/OrderQaColumn/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './OrderQaColumn';

--- a/src/views/Order/common/OrderContainer/style.ts
+++ b/src/views/Order/common/OrderContainer/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const OrderContainerStyle = styled.article`
+  background-color: white;
   border: 1px solid ${props => props.theme.color.pip_gray_01};
 `;
 


### PR DESCRIPTION
# What is this PR? 🔍
주문 비교 영역에 주문 패킹 리스트 데이터 적용

# Changes ✏️
1. 주문 비교 영역에 주문 패킹 리스트 데이터 적용
2. 주문 요청에 사용되는 상수 및 타입 생성, 적용
3. 주문상세 테이블에 일치여부 column 추가 및 필터 기능 적용

# ScreenShot 📷
<table>
<tr>
<td>동영상</td>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/43962775/186251280-e01a7588-4d83-4371-823a-799a8ff6d793.mov
</td>
</tr>
</table>

# Checklist ☑️
- [x] 스캔 버튼을 눌렀을 때 정상적으로 주문 패킹 리스트 데이터가 적용되는지
- [x] 주문 상세 테이블의 일치여부 column에 필터가 정상적으로 적용 되는지