### PR TITLE
주문 처리 여부에 따라 Ai 인식결과 테이블에 색 추가

### DIFF
--- a/src/hooks/order/useOrderDetail.ts
+++ b/src/hooks/order/useOrderDetail.ts
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { Modal } from 'antd';
 
 import { useOrderListUpdate } from '@hooks/query/order/useOrderListUpdate';
-import { ORDER_PACKING_STATUS } from '@constants/order/order';
+import useSessionStorage from '@hooks/common/useSessionStorage';
+import { packingInfoType } from '@hooks/query/order/types';
+import { ORDER_LIST_KEY, ORDER_PACKING_STATUS } from '@constants/order/order';
 
 /**
  * 주문 번호를 관리하는 커스텀 훅
@@ -19,6 +21,14 @@ export const useOrderDetail = () => {
   const { mutate } = useOrderListUpdate(orderId);
 
   /**
+   * 포장 리스트 정보 및 작업 상태
+   */
+  const {
+    sessionState: packingListState,
+    setSessionState: setPackingListState,
+  } = useSessionStorage<packingInfoType[]>(ORDER_LIST_KEY.PACKING, []);
+
+  /**
    * 정상 완료 버튼을 눌렀을 때
    */
   const onPackingDone = () => {
@@ -32,6 +42,26 @@ export const useOrderDetail = () => {
           status: ORDER_PACKING_STATUS.DONE,
         });
         setOrderId(null);
+
+        /**
+         * 마지막 주문 정보를 삭제 후 새로운 정보(주문 처리 여부, 처리 상태)를 넣어서 덮어씌우기
+         */
+        const prevPackingId =
+          packingListState[packingListState.length - 1].packingId;
+        const prevIsMatched =
+          packingListState[packingListState.length - 1].isMatched;
+
+        packingListState.pop();
+
+        setPackingListState(prev => [
+          ...prev,
+          {
+            packingId: prevPackingId,
+            isMatched: prevIsMatched,
+            isChecked: true,
+            status: ORDER_PACKING_STATUS.DONE,
+          },
+        ]);
       },
     });
   };
@@ -50,6 +80,26 @@ export const useOrderDetail = () => {
           status: ORDER_PACKING_STATUS.HOLD,
         });
         setOrderId(null);
+
+        /**
+         * 마지막 주문 정보를 삭제 후 새로운 정보(주문 처리 여부, 처리 상태)를 넣어서 덮어씌우기
+         */
+        const prevPackingId =
+          packingListState[packingListState.length - 1].packingId;
+        const prevIsMatched =
+          packingListState[packingListState.length - 1].isMatched;
+
+        packingListState.pop();
+
+        setPackingListState(prev => [
+          ...prev,
+          {
+            packingId: prevPackingId,
+            isMatched: prevIsMatched,
+            isChecked: true,
+            status: ORDER_PACKING_STATUS.HOLD,
+          },
+        ]);
       },
     });
   };
@@ -59,5 +109,7 @@ export const useOrderDetail = () => {
     setOrderId,
     onPackingDone,
     onPackingHold,
+    packingListState,
+    setPackingListState,
   };
 };

--- a/src/hooks/query/order/types.ts
+++ b/src/hooks/query/order/types.ts
@@ -46,11 +46,25 @@ export type refrigerantsOptionType = {
 };
 
 /**
- * 주문 번호와 해당 주문과 Ai 검출 결과가 일치하는지 여부
+ * 스캔한 주문에 대한 정보
  */
 export type packingInfoType = {
+  /**
+   * 주문 번호
+   */
   packingId: number;
+  /**
+   * 주문 정보와 Ai 인식 결과가 일치하는지
+   */
   isMatched: boolean | string;
+  /**
+   * 주문이 처리되었는지 여부
+   */
+  isChecked?: boolean;
+  /**
+   * 주문 처리 상태
+   */
+  status?: orderPackingStatusType;
 };
 
 /**

--- a/src/views/Order/OrderAiQaSection/OrderAiQaSection.tsx
+++ b/src/views/Order/OrderAiQaSection/OrderAiQaSection.tsx
@@ -1,27 +1,23 @@
-import React, { FC, useEffect } from 'react';
+import React, { Dispatch, FC, SetStateAction, useEffect } from 'react';
 
 import { packingInfoType } from '@hooks/query/order/types';
 import { useOrderList } from '@hooks/query/order/useOrderList';
-import useSessionStorage from '@hooks/common/useSessionStorage';
-import { ORDER_LIST_KEY } from '@constants/order/order';
+import { ORDER_PACKING_STATUS } from '@constants/order/order';
 import AiQaColumn from '@views/Order/column/AiQaColumn';
 import { OrderAiQaSectionStyle, OrderQaListTableStyle } from './style';
 
 interface IOrderAiQaSectionProps {
   orderId: number | null;
+  packingListState: packingInfoType[];
+  setPackingListState: Dispatch<SetStateAction<packingInfoType[]>>;
 }
 
 const OrderAiQaSection: FC<IOrderAiQaSectionProps> = props => {
-  const { orderId } = props;
+  const { orderId, packingListState, setPackingListState } = props;
 
   const { data } = useOrderList(orderId, {
     enabled: orderId !== null && orderId > 0,
   });
-
-  const {
-    sessionState: packingListState,
-    setSessionState: setPackingListState,
-  } = useSessionStorage<packingInfoType[]>(ORDER_LIST_KEY.PACKING, []);
 
   useEffect(() => {
     if (!data?.data?.packingInfo) return;
@@ -41,9 +37,22 @@ const OrderAiQaSection: FC<IOrderAiQaSectionProps> = props => {
     <OrderAiQaSectionStyle>
       <div className="packing-btn">포장 완료 목록</div>
       <OrderQaListTableStyle
-        rowClassName={record =>
-          record.isMatched === '이상 없음' ? 'matched' : 'unmatched'
-        }
+        rowClassName={record => {
+          /**
+           * 아직 주문이 처리되지 않았을 경우
+           */
+          if (!record.isChecked) return '';
+
+          /**
+           * 주문 처리 상태가 정상 완료 되었을 경우
+           */
+          if (record.status === ORDER_PACKING_STATUS.DONE) return 'checked';
+
+          /**
+           * 주문 처리 상태가 누락 보고 되었을 경우
+           */
+          return 'unchecked';
+        }}
         columns={AiQaColumn()}
         dataSource={packingListState}
         pagination={{ showSizeChanger: false }}

--- a/src/views/Order/OrderAiQaSection/style.ts
+++ b/src/views/Order/OrderAiQaSection/style.ts
@@ -20,6 +20,14 @@ export const OrderAiQaSectionStyle = styled.section`
   .ant-table-tbody > tr.ant-table-row:hover > td {
     background: none !important;
   }
+
+  .checked {
+    background-color: ${props => props.theme.color.pip_green_02};
+  }
+
+  .unchecked {
+    background-color: ${props => props.theme.color.pip_pink};
+  }
 `;
 
 export const OrderQaListTableStyle = styled(Table)`

--- a/src/views/Order/OrderContent/OrderContent.tsx
+++ b/src/views/Order/OrderContent/OrderContent.tsx
@@ -10,15 +10,25 @@ import OrderDetailSection from '@views/Order/OrderDetailSection';
 import { OrderContentStyle } from './style';
 
 const OrderContent = () => {
-  const { orderId, setOrderId, onPackingDone, onPackingHold } =
-    useOrderDetail();
+  const {
+    orderId,
+    setOrderId,
+    onPackingDone,
+    onPackingHold,
+    packingListState,
+    setPackingListState,
+  } = useOrderDetail();
 
   return (
     <OrderContentStyle>
       <ErrorBoundary FallbackComponent={Error400}>
         <Suspense fallback={<Loading />}>
           {/* Ai 인식결과 테이블 영역 */}
-          <OrderAiQaSection orderId={orderId} />
+          <OrderAiQaSection
+            orderId={orderId}
+            packingListState={packingListState}
+            setPackingListState={setPackingListState}
+          />
           {/* 주문 비교 테이블 영역 */}
           <OrderDetailSection orderId={orderId} />
           {/* 주문 인식 결과 옵션 영역 */}


### PR DESCRIPTION
# What is this PR? 🔍
주문 처리 여부에 따라 Ai 인식결과 테이블에 색 추가

# Changes ✏️
주문 처리가 정상 완료 되었을 경우 : 초록색
주문 처리가 누락 보고 되었을 경우 : 빨강색

으로 테이블의 각 주문 row에 대해서 색깔 추가

# ScreenShot 📷
<table>
<tr>
<td>동영상</td>
<td>이전 화면</td>
<td>작업 후 화면</td>
</tr>
<tr>
<td>
기능
</td>
<td>

https://user-images.githubusercontent.com/43962775/187367001-beec550c-2cbe-455b-916b-23a85f1cac12.mov
</td>
<td>

https://user-images.githubusercontent.com/43962775/187367270-a8db96aa-04b0-4cd6-b947-6a4c7d6bc964.mov
</td>
</tr>
</table>

# Checklist ☑️
- [x] 스캔한 주문을 누락 보고 또는 정상 완료를 눌렀을 때 해당 상태에 맞게 Ai 인식결과 테이블에 색이 적용 되었는지